### PR TITLE
Fix/error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,13 @@ module.exports = function (zipPath, opts, cb) {
 
       var cancelled = false
 
+      zipfile.on('error', function (err) {
+        if (err) {
+          cancelled = true
+          return cb(err)
+        }
+      })
+
       zipfile.readEntry()
 
       zipfile.on('close', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/extract-zip",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "unzip a zip file into a directory using 100% javascript",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "extract-zip",
+  "name": "@vtex/extract-zip",
   "version": "1.6.7",
   "description": "unzip a zip file into a directory using 100% javascript",
   "main": "index.js",

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
+# Fork motivation
+
+We forked this project in order to solve an error handling issue that was pending for several months in the original project. See [this PR in `builder-hub`](https://github.com/vtex/builder-hub/pull/216) for context.
+
 # extract-zip
 
 Unzip written in pure JavaScript. Extracts a zip into a directory. Available as a library or a command line program.


### PR DESCRIPTION
This PR adds error handling when unzipping files (the motivation for forking the original project), which will hopefully solve some i[ssues in `builder-hub`](https://github.com/vtex/builder-hub/pull/216).

We noticed `extract-zip` has an open issue ([from March 2018](https://github.com/maxogden/extract-zip/issues/65)) and two very similar PR's ([one from November 2017](https://github.com/maxogden/extract-zip/pull/63) and [one from March 2018](https://github.com/maxogden/extract-zip/pull/67)) that supposedly solve the issue. However, those remain un-merged after several months.

Thus, we forked the project and just copied the code from one of those PR's.